### PR TITLE
Context with HTTP Client and DB Accessing

### DIFF
--- a/api/handlers/audio/audio.go
+++ b/api/handlers/audio/audio.go
@@ -1,6 +1,9 @@
 package haudio
 
-import supload "github.com/rice9547/hakka_story/service/upload"
+import (
+	"context"
+	supload "github.com/rice9547/hakka_story/service/upload"
+)
 
 type Audio struct {
 	uploader  *supload.UploadService
@@ -8,7 +11,7 @@ type Audio struct {
 }
 
 type audioGenerator interface {
-	Text2Speech(prompt string) ([]byte, error)
+	Text2Speech(ctx context.Context, prompt string) ([]byte, error)
 }
 
 func New(uploader *supload.UploadService, generator audioGenerator) *Audio {

--- a/api/handlers/audio/generate.go
+++ b/api/handlers/audio/generate.go
@@ -42,7 +42,7 @@ func (h *Audio) Generate(c *gin.Context) {
 		return
 	}
 
-	data, err := h.generator.Text2Speech(req.Prompt)
+	data, err := h.generator.Text2Speech(c.Request.Context(), req.Prompt)
 	if err != nil {
 		errors.ErrorHandler(c, err)
 		return

--- a/api/handlers/audio/generate.go
+++ b/api/handlers/audio/generate.go
@@ -53,7 +53,7 @@ func (h *Audio) Generate(c *gin.Context) {
 		Header:   make(textproto.MIMEHeader),
 	}
 	header.Header.Add("Content-Type", "audio/mpeg")
-	url, err := h.uploader.UploadAudio(c, bytes.NewReader(data), header)
+	url, err := h.uploader.UploadAudio(c.Request.Context(), bytes.NewReader(data), header)
 	if err != nil {
 		errors.ErrorHandler(c, err)
 		return

--- a/api/handlers/audio/upload.go
+++ b/api/handlers/audio/upload.go
@@ -39,7 +39,7 @@ func (h *Audio) Upload(c *gin.Context) {
 	}
 	defer file.Close()
 
-	url, err := h.uploader.UploadAudio(c, file, header)
+	url, err := h.uploader.UploadAudio(c.Request.Context(), file, header)
 	if err != nil {
 		if errors.Is(err, errors.ErrUnsupportedFileType) {
 			response.Error(c, http.StatusBadRequest, "unsupported file type")

--- a/api/handlers/category/create.go
+++ b/api/handlers/category/create.go
@@ -26,7 +26,7 @@ func (h *Category) Create(c *gin.Context) {
 		response.Error(c, 400, err.Error())
 	}
 
-	category, err = h.service.Create(category)
+	category, err = h.service.Create(c.Request.Context(), category)
 	if err != nil {
 		response.Error(c, 500, fmt.Sprintf("Failed to create category, err: %v", err))
 		return

--- a/api/handlers/category/delete.go
+++ b/api/handlers/category/delete.go
@@ -29,7 +29,7 @@ func (h *Category) Delete(c *gin.Context) {
 		return
 	}
 
-	if err = h.service.DeleteByID(id); err != nil {
+	if err = h.service.DeleteByID(c.Request.Context(), id); err != nil {
 		if errors.Is(err, errors.ErrStoryNotFound) {
 			errors.ErrorHandler(c, errors.NewAppError(http.StatusNotFound, err, "Story not found"))
 			return

--- a/api/handlers/category/list.go
+++ b/api/handlers/category/list.go
@@ -19,7 +19,7 @@ import (
 // @Router       /category [get]
 func (h *Category) List(c *gin.Context) {
 	name := c.DefaultQuery("name", "")
-	categories, err := h.service.ListByName(name)
+	categories, err := h.service.ListByName(c.Request.Context(), name)
 	if err != nil {
 		response.Error(c, 500, fmt.Sprintf("Failed to retrieve categories, err: %v", err))
 		return

--- a/api/handlers/category/update.go
+++ b/api/handlers/category/update.go
@@ -35,7 +35,7 @@ func (h *Category) Update(c *gin.Context) {
 		return
 	}
 
-	category, err = h.service.Update(id, category.Name)
+	category, err = h.service.Update(c.Request.Context(), id, category.Name)
 	if err != nil {
 		if errors.Is(err, errors.ErrCategoryNotFound) {
 			response.Error(c, 404, "Category not found")

--- a/api/handlers/image/generate.go
+++ b/api/handlers/image/generate.go
@@ -53,7 +53,7 @@ func (h *Image) Generate(c *gin.Context) {
 		Header:   make(textproto.MIMEHeader),
 	}
 	header.Header.Add("Content-Type", "image/png")
-	url, err := h.uploader.UploadImage(c, bytes.NewReader(data), header)
+	url, err := h.uploader.UploadImage(c.Request.Context(), bytes.NewReader(data), header)
 	if err != nil {
 		errors.ErrorHandler(c, err)
 		return

--- a/api/handlers/image/generate.go
+++ b/api/handlers/image/generate.go
@@ -42,7 +42,7 @@ func (h *Image) Generate(c *gin.Context) {
 		return
 	}
 
-	_, data, err := h.generator.Text2Image(req.Prompt)
+	_, data, err := h.generator.Text2Image(c.Request.Context(), req.Prompt)
 	if err != nil {
 		errors.ErrorHandler(c, err)
 		return

--- a/api/handlers/image/image.go
+++ b/api/handlers/image/image.go
@@ -1,6 +1,7 @@
 package himage
 
 import (
+	"context"
 	"github.com/rice9547/hakka_story/lib/openai"
 	supload "github.com/rice9547/hakka_story/service/upload"
 )
@@ -11,7 +12,7 @@ type Image struct {
 }
 
 type imageGenerator interface {
-	Text2Image(prompt string) (string, []byte, error)
+	Text2Image(ctx context.Context, prompt string) (string, []byte, error)
 }
 
 func New(uploader *supload.UploadService, generator *openai.Client) *Image {

--- a/api/handlers/image/upload.go
+++ b/api/handlers/image/upload.go
@@ -39,7 +39,7 @@ func (h *Image) Upload(c *gin.Context) {
 	}
 	defer file.Close()
 
-	url, err := h.uploader.UploadImage(c, file, header)
+	url, err := h.uploader.UploadImage(c.Request.Context(), file, header)
 	if err != nil {
 		if errors.Is(err, errors.ErrUnsupportedFileType) {
 			response.Error(c, http.StatusBadRequest, "unsupported file type")

--- a/api/handlers/story/create.go
+++ b/api/handlers/story/create.go
@@ -98,7 +98,7 @@ func (h *Story) Create(c *gin.Context) {
 		return
 	}
 
-	if err = h.service.CreateStory(story); err != nil {
+	if err = h.service.CreateStory(c.Request.Context(), story); err != nil {
 		errors.ErrorHandler(c, errors.NewAppError(http.StatusInternalServerError, err, "Failed to create story"))
 		return
 	}

--- a/api/handlers/story/delete.go
+++ b/api/handlers/story/delete.go
@@ -29,7 +29,7 @@ func (h *Story) Delete(c *gin.Context) {
 		return
 	}
 
-	if err = h.service.DeleteByID(id); err != nil {
+	if err = h.service.DeleteByID(c.Request.Context(), id); err != nil {
 		if errors.Is(err, errors.ErrStoryNotFound) {
 			errors.ErrorHandler(c, errors.NewAppError(http.StatusNotFound, err, "Story not found"))
 			return

--- a/api/handlers/story/get.go
+++ b/api/handlers/story/get.go
@@ -26,7 +26,7 @@ func (h *Story) Get(c *gin.Context) {
 		return
 	}
 
-	story, err := h.service.GetStory(id)
+	story, err := h.service.GetStory(c.Request.Context(), id)
 	if err != nil {
 		errors.ErrorHandler(c, errors.NewAppError(http.StatusNotFound, err, "Story not found"))
 		return

--- a/api/handlers/story/list.go
+++ b/api/handlers/story/list.go
@@ -33,9 +33,9 @@ func (h *Story) List(c *gin.Context) {
 		err     error
 	)
 	if len(categoryNames) == 0 {
-		stories, err = h.service.ListStory()
+		stories, err = h.service.ListStory(c.Request.Context())
 	} else {
-		stories, err = h.service.ListStoryByCategories(categoryNames)
+		stories, err = h.service.ListStoryByCategories(c.Request.Context(), categoryNames)
 	}
 
 	if err != nil {

--- a/api/handlers/story/update.go
+++ b/api/handlers/story/update.go
@@ -37,7 +37,7 @@ func (h *Story) Update(c *gin.Context) {
 		return
 	}
 
-	if err = h.service.UpdateByID(id, story); err != nil {
+	if err = h.service.UpdateByID(c.Request.Context(), id, story); err != nil {
 		if errors.Is(err, errors.ErrStoryNotFound) {
 			errors.ErrorHandler(c, errors.NewAppError(http.StatusNotFound, err, "Story not found"))
 			return

--- a/api/handlers/translate/hakka.go
+++ b/api/handlers/translate/hakka.go
@@ -1,6 +1,7 @@
 package htranslate
 
 import (
+	"context"
 	"github.com/gin-gonic/gin"
 
 	"github.com/rice9547/hakka_story/lib/response"
@@ -12,7 +13,7 @@ type (
 	}
 
 	textGenerator interface {
-		Text2Text(text string) (string, error)
+		Text2Text(ctx context.Context, text string) (string, error)
 	}
 
 	TranslateRequest struct {
@@ -47,7 +48,7 @@ func (t *Translate) TranslateHakka(c *gin.Context) {
 		return
 	}
 
-	hakka, err := t.generator.Text2Text(request.Text)
+	hakka, err := t.generator.Text2Text(c.Request.Context(), request.Text)
 	if err != nil {
 		response.Error(c, 500, "Failed to translate")
 		return

--- a/domain/category/repository.go
+++ b/domain/category/repository.go
@@ -1,8 +1,10 @@
 package dcategory
 
+import "context"
+
 type Repository interface {
-	Save(c *Category) error
-	ListByKeyword(keyword string) ([]Category, error)
-	UpdateByID(id uint64, s *Category) error
-	DeleteByID(id uint64) error
+	Save(ctx context.Context, c *Category) error
+	ListByKeyword(ctx context.Context, keyword string) ([]Category, error)
+	UpdateByID(ctx context.Context, id uint64, s *Category) error
+	DeleteByID(ctx context.Context, id uint64) error
 }

--- a/domain/story/repository.go
+++ b/domain/story/repository.go
@@ -1,10 +1,12 @@
 package dstory
 
+import "context"
+
 type Repository interface {
-	Save(s *Story) error
-	List() ([]Story, error)
-	FilterByCategories(categoryNames []string) ([]Story, error)
-	GetByID(id uint64) (*Story, error)
-	UpdateByID(id uint64, s *Story) error
-	DeleteByID(id uint64) error
+	Save(ctx context.Context, s *Story) error
+	List(ctx context.Context) ([]Story, error)
+	FilterByCategories(ctx context.Context, categoryNames []string) ([]Story, error)
+	GetByID(ctx context.Context, id uint64) (*Story, error)
+	UpdateByID(ctx context.Context, id uint64, s *Story) error
+	DeleteByID(ctx context.Context, id uint64) error
 }

--- a/lib/openai/client.go
+++ b/lib/openai/client.go
@@ -1,13 +1,18 @@
 package openai
 
-import "github.com/rice9547/hakka_story/config"
+import (
+	"github.com/rice9547/hakka_story/config"
+	"net/http"
+)
 
 type Client struct {
-	apiKey string
+	apiKey     string
+	httpClient *http.Client
 }
 
 func New(conf config.OpenAI) *Client {
 	return &Client{
-		apiKey: conf.APIKey,
+		apiKey:     conf.APIKey,
+		httpClient: &http.Client{},
 	}
 }

--- a/lib/openai/text2img.go
+++ b/lib/openai/text2img.go
@@ -38,8 +38,7 @@ func (c *Client) Text2Image(ctx context.Context, prompt string) (string, []byte,
 	req.Header.Set("Authorization", "Bearer "+c.apiKey)
 	req.Header.Set("Content-Type", "application/json")
 
-	client := &http.Client{}
-	resp, err := client.Do(req)
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return "", nil, err
 	}

--- a/lib/openai/text2img.go
+++ b/lib/openai/text2img.go
@@ -2,6 +2,7 @@ package openai
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -22,7 +23,7 @@ type ImageResponse struct {
 	} `json:"data"`
 }
 
-func (c *Client) Text2Image(prompt string) (string, []byte, error) {
+func (c *Client) Text2Image(ctx context.Context, prompt string) (string, []byte, error) {
 	requestData := ImageRequest{
 		Prompt: prompt,
 		N:      1,
@@ -30,7 +31,7 @@ func (c *Client) Text2Image(prompt string) (string, []byte, error) {
 	}
 
 	jsonData, _ := json.Marshal(requestData)
-	req, err := http.NewRequest("POST", imageApiUrl, bytes.NewBuffer(jsonData))
+	req, err := http.NewRequestWithContext(ctx, "POST", imageApiUrl, bytes.NewBuffer(jsonData))
 	if err != nil {
 		return "", nil, err
 	}

--- a/lib/openai/text2speech.go
+++ b/lib/openai/text2speech.go
@@ -34,8 +34,7 @@ func (c *Client) Text2Speech(ctx context.Context, prompt string) ([]byte, error)
 	req.Header.Set("Authorization", "Bearer "+c.apiKey)
 	req.Header.Set("Content-Type", "application/json")
 
-	client := &http.Client{}
-	resp, err := client.Do(req)
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/openai/text2speech.go
+++ b/lib/openai/text2speech.go
@@ -2,6 +2,7 @@ package openai
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -20,7 +21,7 @@ type AudioResponse struct {
 	AudioContent string `json:"audio_content"`
 }
 
-func (c *Client) Text2Speech(prompt string) ([]byte, error) {
+func (c *Client) Text2Speech(ctx context.Context, prompt string) ([]byte, error) {
 	requestData := AudioRequest{
 		Model: "tts-1",
 		Input: prompt,
@@ -29,7 +30,7 @@ func (c *Client) Text2Speech(prompt string) ([]byte, error) {
 
 	jsonData, _ := json.Marshal(requestData)
 
-	req, _ := http.NewRequest("POST", speechApiUrl, bytes.NewBuffer(jsonData))
+	req, _ := http.NewRequestWithContext(ctx, "POST", speechApiUrl, bytes.NewBuffer(jsonData))
 	req.Header.Set("Authorization", "Bearer "+c.apiKey)
 	req.Header.Set("Content-Type", "application/json")
 

--- a/lib/openai/text2text.go
+++ b/lib/openai/text2text.go
@@ -2,6 +2,7 @@ package openai
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -26,7 +27,7 @@ type Response struct {
 	} `json:"choices"`
 }
 
-func (c *Client) Text2Text(prompt string) (string, error) {
+func (c *Client) Text2Text(ctx context.Context, prompt string) (string, error) {
 	messages := []Message{
 		{Role: "system", Content: "你是一個客語專家，接下來你會收到一些中文的故事段落，請翻譯成四縣腔的客語，不需要額外的回覆。"},
 		{Role: "user", Content: prompt},
@@ -38,7 +39,7 @@ func (c *Client) Text2Text(prompt string) (string, error) {
 	}
 
 	jsonData, _ := json.Marshal(requestData)
-	req, _ := http.NewRequest("POST", textApiUrl, bytes.NewBuffer(jsonData))
+	req, _ := http.NewRequestWithContext(ctx, "POST", textApiUrl, bytes.NewBuffer(jsonData))
 	req.Header.Set("Authorization", "Bearer "+c.apiKey)
 	req.Header.Set("Content-Type", "application/json")
 

--- a/lib/openai/text2text.go
+++ b/lib/openai/text2text.go
@@ -43,8 +43,7 @@ func (c *Client) Text2Text(ctx context.Context, prompt string) (string, error) {
 	req.Header.Set("Authorization", "Bearer "+c.apiKey)
 	req.Header.Set("Content-Type", "application/json")
 
-	client := &http.Client{}
-	resp, err := client.Do(req)
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return "", err
 	}

--- a/persistence/mysql/category.go
+++ b/persistence/mysql/category.go
@@ -1,6 +1,7 @@
 package mysql
 
 import (
+	"context"
 	"gorm.io/gorm"
 
 	dcategory "github.com/rice9547/hakka_story/domain/category"
@@ -15,20 +16,22 @@ func NewCategory(client *Client) dcategory.Repository {
 	return &CategoryRepository{DB: client.DB()}
 }
 
-func (r *CategoryRepository) Save(c *dcategory.Category) error {
-	return r.DB.Save(c).Error
+func (r *CategoryRepository) Save(ctx context.Context, c *dcategory.Category) error {
+	return r.DB.WithContext(ctx).Save(c).Error
 }
 
-func (r *CategoryRepository) ListByKeyword(keyword string) ([]dcategory.Category, error) {
+func (r *CategoryRepository) ListByKeyword(ctx context.Context, keyword string) ([]dcategory.Category, error) {
 	categories := make([]dcategory.Category, 0)
-	err := r.DB.Model(&dcategory.Category{}).
+	err := r.DB.WithContext(ctx).
+		Model(&dcategory.Category{}).
 		Where("name LIKE ?", "%"+keyword+"%").
 		Find(&categories).Error
 	return categories, err
 }
 
-func (r *CategoryRepository) UpdateByID(id uint64, category *dcategory.Category) error {
-	result := r.DB.Model(&dcategory.Category{}).
+func (r *CategoryRepository) UpdateByID(ctx context.Context, id uint64, category *dcategory.Category) error {
+	result := r.DB.WithContext(ctx).
+		Model(&dcategory.Category{}).
 		Where("id = ?", id).
 		Update("name", category.Name)
 	if result.Error != nil {
@@ -42,7 +45,7 @@ func (r *CategoryRepository) UpdateByID(id uint64, category *dcategory.Category)
 	return nil
 }
 
-func (r *CategoryRepository) DeleteByID(id uint64) error {
+func (r *CategoryRepository) DeleteByID(ctx context.Context, id uint64) error {
 	result := r.DB.Delete(&dcategory.Category{}, id)
 	if result.Error != nil {
 		return result.Error

--- a/service/category/category.go
+++ b/service/category/category.go
@@ -1,13 +1,16 @@
 package scategory
 
-import dcategory "github.com/rice9547/hakka_story/domain/category"
+import (
+	"context"
+	dcategory "github.com/rice9547/hakka_story/domain/category"
+)
 
 type (
 	Service interface {
-		Create(c *dcategory.Category) (*dcategory.Category, error)
-		ListByName(name string) ([]dcategory.Category, error)
-		Update(id uint64, name string) (*dcategory.Category, error)
-		DeleteByID(id uint64) error
+		Create(ctx context.Context, c *dcategory.Category) (*dcategory.Category, error)
+		ListByName(ctx context.Context, name string) ([]dcategory.Category, error)
+		Update(ctx context.Context, id uint64, name string) (*dcategory.Category, error)
+		DeleteByID(ctx context.Context, id uint64) error
 	}
 
 	service struct {
@@ -19,16 +22,16 @@ func New(repo dcategory.Repository) Service {
 	return &service{repo: repo}
 }
 
-func (s *service) Create(c *dcategory.Category) (*dcategory.Category, error) {
-	if err := s.repo.Save(c); err != nil {
+func (s *service) Create(ctx context.Context, c *dcategory.Category) (*dcategory.Category, error) {
+	if err := s.repo.Save(ctx, c); err != nil {
 		return nil, err
 	}
 
 	return c, nil
 }
 
-func (s *service) ListByName(name string) ([]dcategory.Category, error) {
-	categories, err := s.repo.ListByKeyword(name)
+func (s *service) ListByName(ctx context.Context, name string) ([]dcategory.Category, error) {
+	categories, err := s.repo.ListByKeyword(ctx, name)
 	if err != nil {
 		return nil, err
 	}
@@ -36,13 +39,13 @@ func (s *service) ListByName(name string) ([]dcategory.Category, error) {
 	return categories, nil
 }
 
-func (s *service) Update(id uint64, name string) (*dcategory.Category, error) {
+func (s *service) Update(ctx context.Context, id uint64, name string) (*dcategory.Category, error) {
 	category := &dcategory.Category{
 		ID:   id,
 		Name: name,
 	}
 
-	err := s.repo.UpdateByID(id, category)
+	err := s.repo.UpdateByID(ctx, id, category)
 	if err != nil {
 		return nil, err
 	}
@@ -50,6 +53,6 @@ func (s *service) Update(id uint64, name string) (*dcategory.Category, error) {
 	return category, nil
 }
 
-func (s *service) DeleteByID(id uint64) error {
-	return s.repo.DeleteByID(id)
+func (s *service) DeleteByID(ctx context.Context, id uint64) error {
+	return s.repo.DeleteByID(ctx, id)
 }

--- a/service/story/story.go
+++ b/service/story/story.go
@@ -1,16 +1,17 @@
 package sstory
 
 import (
+	"context"
 	dstory "github.com/rice9547/hakka_story/domain/story"
 )
 
 type Service interface {
-	CreateStory(s *dstory.Story) error
-	ListStory() ([]dstory.Story, error)
-	ListStoryByCategories(categoryNames []string) ([]dstory.Story, error)
-	GetStory(id uint64) (*dstory.Story, error)
-	UpdateByID(id uint64, s *dstory.Story) error
-	DeleteByID(id uint64) error
+	CreateStory(ctx context.Context, s *dstory.Story) error
+	ListStory(ctx context.Context) ([]dstory.Story, error)
+	ListStoryByCategories(ctx context.Context, categoryNames []string) ([]dstory.Story, error)
+	GetStory(ctx context.Context, id uint64) (*dstory.Story, error)
+	UpdateByID(ctx context.Context, id uint64, s *dstory.Story) error
+	DeleteByID(ctx context.Context, id uint64) error
 }
 
 type service struct {
@@ -21,26 +22,26 @@ func New(repo dstory.Repository) Service {
 	return &service{repo: repo}
 }
 
-func (s *service) CreateStory(st *dstory.Story) error {
-	return s.repo.Save(st)
+func (s *service) CreateStory(ctx context.Context, st *dstory.Story) error {
+	return s.repo.Save(ctx, st)
 }
 
-func (s *service) ListStory() ([]dstory.Story, error) {
-	return s.repo.List()
+func (s *service) ListStory(ctx context.Context) ([]dstory.Story, error) {
+	return s.repo.List(ctx)
 }
 
-func (s *service) ListStoryByCategories(categoryNames []string) ([]dstory.Story, error) {
-	return s.repo.FilterByCategories(categoryNames)
+func (s *service) ListStoryByCategories(ctx context.Context, categoryNames []string) ([]dstory.Story, error) {
+	return s.repo.FilterByCategories(ctx, categoryNames)
 }
 
-func (s *service) GetStory(id uint64) (*dstory.Story, error) {
-	return s.repo.GetByID(id)
+func (s *service) GetStory(ctx context.Context, id uint64) (*dstory.Story, error) {
+	return s.repo.GetByID(ctx, id)
 }
 
-func (s *service) UpdateByID(id uint64, st *dstory.Story) error {
-	return s.repo.UpdateByID(id, st)
+func (s *service) UpdateByID(ctx context.Context, id uint64, st *dstory.Story) error {
+	return s.repo.UpdateByID(ctx, id, st)
 }
 
-func (s *service) DeleteByID(id uint64) error {
-	return s.repo.DeleteByID(id)
+func (s *service) DeleteByID(ctx context.Context, id uint64) error {
+	return s.repo.DeleteByID(ctx, id)
 }


### PR DESCRIPTION
Add `context.Context` for HTTP Clients and DB Accessing, it could useful to integrate Open Telemetry.

> Note: In most of cases, use `*gin.Context.Request.Context()` instead of `*gin.Context` directly, see more information: https://stackoverflow.com/questions/69878225/parent-context-context-vs-gin-contect-request-context-vs-gin-context